### PR TITLE
Use dev-container image

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vdaas/vald/vald-ci-container:nightly
+      image: ghcr.io/vdaas/vald/vald-dev-container:nightly
       options: "--add-host host.docker.internal:host-gateway"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,7 +11,7 @@ jobs:
     name: "trigger FOSSA scan"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vdaas/vald/vald-ci-container:nightly
+      image: ghcr.io/vdaas/vald/vald-dev-container:nightly
     if: github.ref == 'refs/heads/main' || github.event.action == 'labeled' && github.event.label.name == 'actions/fossa'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container images used in GitHub Actions workflows for end-to-end testing and FOSSA scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->